### PR TITLE
Fix conditionals to return boolean instead of int

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: "Install for user {{ toolbox_install_for_user }}"
   become: true
   become_user: "{{ toolbox_install_for_user }}"
-  when: toolbox_install_for_user | length
+  when: toolbox_install_for_user | length > 0
   block:
 
     - name: "Ensure installation dir exists"
@@ -84,4 +84,4 @@
     value: "{{ inotify_max_user_watches }}"
     state: "present"
     reload: "yes"
-  when: toolbox_install_for_user | length
+  when: toolbox_install_for_user | length > 0


### PR DESCRIPTION
## Summary
- Ansible core 2.20+ strictly requires `when` conditionals to evaluate to a boolean
- `toolbox_install_for_user | length` returns an `int`, which now causes a fatal error:
  ```
  Conditional result (False) was derived from value of type 'int'. Conditionals must have a boolean result.
  ```
- Changed `| length` to `| length > 0` on lines 6 and 87 of `tasks/main.yml` to produce a proper boolean

## Test plan
- [x] Verified the fix resolves the error on Ansible core 2.20.3